### PR TITLE
fix the issues mentioned in the thread

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -6,3 +6,4 @@
 #define __need_NULL
 #include <stddef.h>
 char* itoa(long value, char* result, int base);
+char* utoa(unsigned long value, volatile char* result, int base);

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -5,4 +5,4 @@
 #define __need_wint_t
 #define __need_NULL
 #include <stddef.h>
-char* itoa(int value, char* result, int base);
+char* itoa(long value, char* result, int base);

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -29,15 +29,17 @@ Please report this to Techflash at https://github.com/techflashYT/Techflash-OS\r
 Please give the following information in the bug report:\r\n\
 Error: "
 	); // Puts is slightly faster here since there's no need to check for format specifiers
-	char *rax = "\0\0\0\0\0\0\0\0\0\0";
-	char *rbx = "\0\0\0\0\0\0\0\0\0\0";
-	char *rcx = "\0\0\0\0\0\0\0\0\0\0";
-	char *rdx = "\0\0\0\0\0\0\0\0\0\0";
-	char *rbp = "\0\0\0\0\0\0\0\0\0\0";
-	char *rsp = "\0\0\0\0\0\0\0\0\0\0";
-	char *rsi = "\0\0\0\0\0\0\0\0\0\0";
-	char *rdi = "\0\0\0\0\0\0\0\0\0\0";
-	char *intNo = "\0\0\0\0\0\0\0\0\0\0";
+
+	char rax[17];
+	char rbx[17];
+	char rcx[17];
+	char rdx[17];
+	char rbp[17];
+	char rsp[17];
+	char rsi[17];
+	char rdi[17];
+	char intNo[17];
+
 	itoa(regs.rax, rax, 16);
 	itoa(regs.rbx, rbx, 16);
 	itoa(regs.rcx, rcx, 16);

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -40,15 +40,15 @@ Error: "
 	char rdi[17];
 	char intNo[17];
 
-	itoa(regs.rax, rax, 16);
-	itoa(regs.rbx, rbx, 16);
-	itoa(regs.rcx, rcx, 16);
-	itoa(regs.rdx, rdx, 16);
-	itoa(regs.rbp, rbp, 16);
-	itoa(regs.userRsp, rsp, 16);
-	itoa(regs.rsi, rsi, 16);
-	itoa(regs.rdi, rdi, 16);
-	itoa(regs.intNo, intNo, 16);
+	utoa(regs.rax, rax, 16);
+	utoa(regs.rbx, rbx, 16);
+	utoa(regs.rcx, rcx, 16);
+	utoa(regs.rdx, rdx, 16);
+	utoa(regs.rbp, rbp, 16);
+	utoa(regs.userRsp, rsp, 16);
+	utoa(regs.rsi, rsi, 16);
+	utoa(regs.rdi, rdi, 16);
+	utoa(regs.intNo, intNo, 16);
 	printf(
 "%s\r\n\
 CPU Registers:\r\n\

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -8,6 +8,7 @@ stdio/puts.o \
 stdio/putchar.o \
 stdio/printf.o \
 stdlib/itoa.o \
+stdlib/utoa.o \
 string/strlen.o \
 string/memset.o \
 string/memcpy.o \
@@ -21,6 +22,7 @@ link=\
 ../build/libc/stdio/putchar.o \
 ../build/libc/stdio/printf.o \
 ../build/libc/stdlib/itoa.o \
+../build/libc/stdlib/utoa.o \
 ../build/libc/string/strlen.o \
 ../build/libc/string/memset.o \
 ../build/libc/string/memcpy.o \

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -1,7 +1,7 @@
 # Based on kernel/Makefile: For copyright notices, please view that file.
 WARN   = -Wall -Wextra -Wstack-protector -Wformat=2 -Wformat-security
 FEATURE= -fdiagnostics-color=always -fno-pic -ffreestanding -fstack-protector-all
-CFLAGS = $(WARN) $(FEATURE) -nostdlib -I../include -Ofast -static -s -std=gnu2x -mcmodel=kernel -march=core2 -mno-3dnow -mno-mmx
+CFLAGS = $(WARN) $(FEATURE) -nostdlib -I../include -Ofast -static -s -std=gnu2x -mcmodel=kernel -march=core2 -mno-3dnow -mno-mmx -g
 
 compile=\
 stdio/puts.o \

--- a/libc/stdlib/itoa.c
+++ b/libc/stdlib/itoa.c
@@ -8,7 +8,7 @@
 	by Lukás Chmela.
 	http://www.strudel.org.uk/itoa/
 */
-char* itoa(int value, char* result, int base) {
+char* itoa(long value, char* result, int base) {
 	// FIXME: (stupid workaround for a bug that I can't figure out, find real fix) if 0 just put zero and return
 	if (value == 0) {
 		*result = '0';
@@ -22,16 +22,16 @@ char* itoa(int value, char* result, int base) {
 	}
 
 	char* ptr = result, *ptr1 = result, tmp_char;
-	int tmp_value;
+	long tmp_value;
 	do {
 		tmp_value = value;
 		value /= base;
-		*ptr++ = "ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" [35 + (tmp_value - value * base)];
+		*ptr++ = "ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ" [(long)35 + (tmp_value - value * base)];
 	}
 	while (value);
 
 	// Apply negative sign
-	if (tmp_value < 0 && base == 10) {
+	if (tmp_value < (long)0 && base == 10) {
 		*ptr++ = '-';
 	}
 	*ptr-- = '\0';

--- a/libc/stdlib/utoa.c
+++ b/libc/stdlib/utoa.c
@@ -1,0 +1,33 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+
+char* utoa(unsigned long value, volatile char* result, int base){
+
+        char buff[sizeof(long)*8/4];
+
+        if(base < 2 || base > 36){
+                *result = '\0';
+                return result;
+        }
+
+        size_t charc = 0;
+
+        do{
+                uintmax_t offset = value % base;
+                value /= base;
+                buff[charc++] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"[offset];
+        }
+        while(value);
+        
+        for(uintmax_t i = 0; i < charc; ++i){
+
+                result[i] = buff[charc-i-1];
+                
+        }
+
+        result[charc] = '\0';
+        
+        return result;
+}
+


### PR DESCRIPTION
- libc: make itoa use long instead of int
- libc: build with debugging symbols
- panic: store results from itoa in char arrays rather than a string literal
- libc: add utoa and make panic use it
