### PR TITLE
make memmove implementation smaller and add missings stdbool.h includes

### DIFF
--- a/include/kernel/hardware/parallel.h
+++ b/include/kernel/hardware/parallel.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdbool.h>
 extern uint16_t LPT1; // LPT1 can be either 0x378 or 0x3BC depending on the BIOS.
 extern uint16_t LPT2;
 extern uint16_t LPT3;

--- a/include/kernel/hardware/serial.h
+++ b/include/kernel/hardware/serial.h
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 extern uint16_t SERIAL_PORT_COM1;
 extern uint16_t SERIAL_PORT_COM2;
 extern uint16_t SERIAL_PORT_COM3;

--- a/iso.sh
+++ b/iso.sh
@@ -10,8 +10,10 @@ if [ ! -f bootboot/bootboot.bin ]; then
 	cd ..
 fi
 cp -r sysroot isodir
-mkdir isodir/BOOTBOOT
+mkdir -p isodir/BOOTBOOT
+if [ ! -f isodir/boot/install ]; then
 mv isodir/boot/tfos.elf isodir/boot/install
+fi
 cp bootboot/bootboot.bin isodir/BOOTBOOT/BOOTBOOT.BIN
 
 # Make initrd

--- a/kernel/hardware/kbdLEDs.c
+++ b/kernel/hardware/kbdLEDs.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdbool.h>
 
 uint8_t valueToSet;
 void keyboardStartSetLED();

--- a/kernel/hardware/parallel/parallel.c
+++ b/kernel/hardware/parallel/parallel.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 MODULE("PARALLEL");
 parallel_t parallel;
 bool structInit = false;

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -148,7 +148,8 @@ __attribute__((noreturn)) void panic(const char* message, volatile registers_t *
 	printf("NOTE: Starting from most recently called function, ending at entry point.\r\n");
 	serial.writeString(SERIAL_PORT_COM1, "NOTE: Starting from most recently called function, ending at entry point.\r\n");
 	// stack trace
-	uint64_t *trace = stackTrace(20);
+	// removed it because the stackTrace function has no implementation
+	/*uint64_t *trace = stackTrace(20);
 	char *addr = malloc(17);
 	if (trace[0] > 20) {
 		trace[0] = 20;
@@ -158,7 +159,7 @@ __attribute__((noreturn)) void panic(const char* message, volatile registers_t *
 		utoa(trace[i], addr, 16);
 		padTo(addr, 16);
 		printf("%i: 0x%s\r\n", i, addr);
-	}
+	}*/
 
 
 	// write panic_screen.sys to the fb

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -148,8 +148,6 @@ __attribute__((noreturn)) void panic(const char* message, volatile registers_t *
 	printf("NOTE: Starting from most recently called function, ending at entry point.\r\n");
 	serial.writeString(SERIAL_PORT_COM1, "NOTE: Starting from most recently called function, ending at entry point.\r\n");
 	// stack trace
-	// removed it because the stackTrace function has no implementation
-	/*uint64_t *trace = stackTrace(20);
 	char *addr = malloc(17);
 	if (trace[0] > 20) {
 		trace[0] = 20;

--- a/kernel/panic.c
+++ b/kernel/panic.c
@@ -157,7 +157,7 @@ __attribute__((noreturn)) void panic(const char* message, volatile registers_t *
 		utoa(trace[i], addr, 16);
 		padTo(addr, 16);
 		printf("%i: 0x%s\r\n", i, addr);
-	}*/
+	}
 
 
 	// write panic_screen.sys to the fb

--- a/libc/string/memmove.c
+++ b/libc/string/memmove.c
@@ -3,29 +3,14 @@
 #include <string.h>
 
 void *memmove(void *dest, const void *src, size_t n) {
-	uint8_t* from = (uint8_t*) src;
-	uint8_t* to = (uint8_t*) dest;
-
-	if (from == to || n == 0) {
-		return dest;
+	unsigned char* dst = (unsigned char*) dest;
+	const unsigned char* srcTemp = (const unsigned char*) src;
+	if (dst < srcTemp) {
+		for (size_t i = 0; i < n; i++)
+			dst[i] = srcTemp[i];
+	} else {
+		for (size_t i = n; i != 0; i--)
+			dst[i-1] = srcTemp[i-1];
 	}
-
-	if (to > from && to - from < (int)n) {
-		// "to" overlaps "from", copy in reverse
-		int i;
-		for (i = (n - 1); i >= 0; i--) {
-			to[i] = from[i];
-		}
-		return dest;
-	}
-	if (from > to && from - to < (int)n) {
-		// "to" overlaps "from", copy forwards
-		size_t i;
-		for (i = 0; i < n; i++) {
-			to[i] = from[i];
-		}
-		return dest;
-	}
-	memcpy(dest, src, n);
 	return dest;
 }

--- a/misc/converted/generate_panic_screen.sh
+++ b/misc/converted/generate_panic_screen.sh
@@ -1,0 +1,2 @@
+#/bin/bash
+python3 convert.py ../panic_screen.png panic_screen.bin

--- a/misc/converted/generate_panic_screen.sh
+++ b/misc/converted/generate_panic_screen.sh
@@ -1,2 +1,3 @@
 #/bin/bash
 python3 convert.py ../panic_screen.png panic_screen.bin
+ 


### PR DESCRIPTION
I made memmove implementation smaller and added missings stdbool.h includes that made the compilation fail.
I also added a little script creating the panic_screen.bin file because the compilation failed because of it missing.